### PR TITLE
Deleted duplicate quotes in quote data

### DIFF
--- a/data/quotes.json
+++ b/data/quotes.json
@@ -1696,32 +1696,12 @@
     "author": "Dr. Seuss"
   },
   {
-    "quote": "Don't cry because it's over, smile because it happened.",
-    "author": "Dr. Seuss"
-  },
-  {
-    "quote": "I'm selfish, impatient and a little insecure. I make mistakes, I am out of control and at times hard to handle. But if you can't handle me at my worst, then you sure as hell don't deserve me at my best.",
-    "author": "Marilyn Monroe"
-  },
-  {
-    "quote": "I'm selfish, impatient and a little insecure. I make mistakes, I am out of control and at times hard to handle. But if you can't handle me at my worst, then you sure as hell don't deserve me at my best.",
-    "author": "Marilyn Monroe"
-  },
-  {
     "quote": "I'm selfish, impatient and a little insecure. I make mistakes, I am out of control and at times hard to handle. But if you can't handle me at my worst, then you sure as hell don't deserve me at my best.",
     "author": "Marilyn Monroe"
   },
   {
     "quote": "Be yourself; everyone else is already taken.",
     "author": "Oscar Wilde"
-  },
-  {
-    "quote": "Two things are infinite: the universe and human stupidity; and I'm not sure about the universe.",
-    "author": "Albert Einstein"
-  },
-  {
-    "quote": "Two things are infinite: the universe and human stupidity; and I'm not sure about the universe.",
-    "author": "Albert Einstein"
   },
   {
     "quote": "Two things are infinite: the universe and human stupidity; and I'm not sure about the universe.",
@@ -1736,14 +1716,6 @@
     "author": "William W. Purkey"
   },
   {
-    "quote": "You've gotta dance like there's nobody watching,Love like you'll never be hurt,Sing like there's nobody listening,And live like it's heaven on earth.",
-    "author": "William W. Purkey"
-  },
-  {
-    "quote": "You've gotta dance like there's nobody watching,Love like you'll never be hurt,Sing like there's nobody listening,And live like it's heaven on earth.",
-    "author": "William W. Purkey"
-  },
-  {
     "quote": "You know you're in love when you can't fall asleep because reality is finally better than your dreams.",
     "author": "Dr. Seuss"
   },
@@ -1752,28 +1724,12 @@
     "author": "Marcus Tullius Cicero"
   },
   {
-    "quote": "A room without books is like a body without a soul.",
-    "author": "Marcus Tullius Cicero"
-  },
-  {
-    "quote": "So many books, so little time.",
-    "author": "Frank Zappa"
-  },
-  {
     "quote": "So many books, so little time.",
     "author": "Frank Zappa"
   },
   {
     "quote": "You only live once, but if you do it right, once is enough.",
     "author": "Mae West"
-  },
-  {
-    "quote": "You only live once, but if you do it right, once is enough.",
-    "author": "Mae West"
-  },
-  {
-    "quote": "Be the change that you wish to see in the world.",
-    "author": "Mahatma Gandhi"
   },
   {
     "quote": "Be the change that you wish to see in the world.",
@@ -1800,16 +1756,8 @@
     "author": "Eleanor Roosevelt,  This is My Story"
   },
   {
-    "quote": "No one can make you feel inferior without your consent.",
-    "author": "Eleanor Roosevelt,  This is My Story"
-  },
-  {
     "quote": "If you tell the truth, you don't have to remember anything.",
     "author": "Mark Twain"
-  },
-  {
-    "quote": "A friend is someone who knows all about you and still loves you.",
-    "author": "Elbert Hubbard"
   },
   {
     "quote": "A friend is someone who knows all about you and still loves you.",
@@ -1828,16 +1776,8 @@
     "author": "Mahatma Gandhi"
   },
   {
-    "quote": "Live as if you were to die tomorrow. Learn as if you were to live forever.",
-    "author": "Mahatma Gandhi"
-  },
-  {
     "quote": "I am so clever that sometimes I don't understand a single word of what I am saying.",
     "author": "Oscar Wilde,  The Happy Prince and Other Stories"
-  },
-  {
-    "quote": "Darkness cannot drive out darkness: only light can do that. Hate cannot drive out hate: only love can do that.",
-    "author": "Martin Luther King Jr.,  A Testament of Hope: The Essential Writings and Speeches"
   },
   {
     "quote": "Darkness cannot drive out darkness: only light can do that. Hate cannot drive out hate: only love can do that.",
@@ -1850,14 +1790,6 @@
   {
     "quote": "Without music, life would be a mistake.",
     "author": "Friedrich Nietzsche,  Twilight of the Idols"
-  },
-  {
-    "quote": "Without music, life would be a mistake.",
-    "author": "Friedrich Nietzsche,  Twilight of the Idols"
-  },
-  {
-    "quote": "Insanity is doing the same thing, over and over again, but expecting different results.",
-    "author": "Narcotics Anonymous"
   },
   {
     "quote": "Insanity is doing the same thing, over and over again, but expecting different results.",
@@ -1880,14 +1812,6 @@
     "author": "Stephen Chbosky,  The Perks of Being a Wallflower"
   },
   {
-    "quote": "We accept the love we think we deserve.",
-    "author": "Stephen Chbosky,  The Perks of Being a Wallflower"
-  },
-  {
-    "quote": "It is better to be hated for what you are than to be loved for what you are not.",
-    "author": "Andr\u00e9 Gide,  Autumn Leaves"
-  },
-  {
     "quote": "It is better to be hated for what you are than to be loved for what you are not.",
     "author": "Andr\u00e9 Gide,  Autumn Leaves"
   },
@@ -1902,14 +1826,6 @@
   {
     "quote": "The person, be it gentleman or lady, who has not pleasure in a good novel, must be intolerably stupid.",
     "author": "Jane Austen,  Northanger Abbey"
-  },
-  {
-    "quote": "The person, be it gentleman or lady, who has not pleasure in a good novel, must be intolerably stupid.",
-    "author": "Jane Austen,  Northanger Abbey"
-  },
-  {
-    "quote": "There are only two ways to live your life. One is as though nothing is a miracle. The other is as though everything is a miracle.",
-    "author": "Albert Einstein"
   },
   {
     "quote": "There are only two ways to live your life. One is as though nothing is a miracle. The other is as though everything is a miracle.",
@@ -1936,10 +1852,6 @@
     "author": "Mark Twain"
   },
   {
-    "quote": "Good friends, good books, and a sleepy conscience: this is the ideal life.",
-    "author": "Mark Twain"
-  },
-  {
     "quote": "Whenever you find yourself on the side of the majority, it is time to reform (or pause and reflect).",
     "author": "Mark Twain"
   },
@@ -1954,10 +1866,6 @@
   {
     "quote": "A woman is like a tea bag; you never know how strong it is until it's in hot water.",
     "author": "Eleanor Roosevelt"
-  },
-  {
-    "quote": "Yesterday is history, tomorrow is a mystery, today is a gift of God, which is why we call it the present.",
-    "author": "Bil Keane"
   },
   {
     "quote": "Yesterday is history, tomorrow is a mystery, today is a gift of God, which is why we call it the present.",
@@ -1984,32 +1892,12 @@
     "author": "Friedrich Nietzsche"
   },
   {
-    "quote": "It is not a lack of love, but a lack of friendship that makes unhappy marriages.",
-    "author": "Friedrich Nietzsche"
-  },
-  {
-    "quote": "The opposite of love is not hate, it's indifference. The opposite of art is not ugliness, it's indifference. The opposite of faith is not heresy, it's indifference. And the opposite of life is not death, it's indifference.",
-    "author": "Elie Wiesel"
-  },
-  {
-    "quote": "The opposite of love is not hate, it's indifference. The opposite of art is not ugliness, it's indifference. The opposite of faith is not heresy, it's indifference. And the opposite of life is not death, it's indifference.",
-    "author": "Elie Wiesel"
-  },
-  {
     "quote": "The opposite of love is not hate, it's indifference. The opposite of art is not ugliness, it's indifference. The opposite of faith is not heresy, it's indifference. And the opposite of life is not death, it's indifference.",
     "author": "Elie Wiesel"
   },
   {
     "quote": "Fairy tales are more than true: not because they tell us that dragons exist, but because they tell us that dragons can be beaten.",
     "author": "Neil Gaiman,  Coraline"
-  },
-  {
-    "quote": "Fairy tales are more than true: not because they tell us that dragons exist, but because they tell us that dragons can be beaten.",
-    "author": "Neil Gaiman,  Coraline"
-  },
-  {
-    "quote": "Outside of a dog, a book is man's best friend. Inside of a dog it's too dark to read.",
-    "author": "Groucho Marx,  The Essential Groucho: Writings For By And About Groucho Marx"
   },
   {
     "quote": "Outside of a dog, a book is man's best friend. Inside of a dog it's too dark to read.",
@@ -2034,10 +1922,6 @@
   {
     "quote": "Never put off till tomorrow what may be done day after tomorrow just as well.",
     "author": "Mark Twain"
-  },
-  {
-    "quote": "I love you without knowing how, or when, or from where. I love you simply, without problems or pride: I love you in this way because I do not know any other way of loving but this, in which there is no I or you, so intimate that your hand upon my chest is my hand, so intimate that when I fall asleep your eyes close.",
-    "author": "Pablo Neruda,  100 Love Sonnets"
   },
   {
     "quote": "I love you without knowing how, or when, or from where. I love you simply, without problems or pride: I love you in this way because I do not know any other way of loving but this, in which there is no I or you, so intimate that your hand upon my chest is my hand, so intimate that when I fall asleep your eyes close.",
@@ -2088,16 +1972,8 @@
     "author": "Douglas Adams,  The Salmon of Doubt"
   },
   {
-    "quote": "I love deadlines. I love the whooshing noise they make as they go by.",
-    "author": "Douglas Adams,  The Salmon of Doubt"
-  },
-  {
     "quote": "It is never too late to be what you might have been.",
     "author": "George Eliot"
-  },
-  {
-    "quote": "Anyone who thinks sitting in church can make you a Christian must also think that sitting in a garage can make you a car.",
-    "author": "Garrison Keillor"
   },
   {
     "quote": "Anyone who thinks sitting in church can make you a Christian must also think that sitting in a garage can make you a car.",
@@ -2122,10 +1998,6 @@
   {
     "quote": "It takes a great deal of bravery to stand up to our enemies, but just as much to stand up to our friends.",
     "author": "J.K. Rowling,  Harry Potter and the Sorcerer's Stone"
-  },
-  {
-    "quote": "Love is that condition in which the happiness of another person is essential to your own.",
-    "author": "Robert A. Heinlein,  Stranger in a Strange Land"
   },
   {
     "quote": "Love is that condition in which the happiness of another person is essential to your own.",
@@ -2164,14 +2036,6 @@
     "author": "Pablo Picasso"
   },
   {
-    "quote": "Everything you can imagine is real.",
-    "author": "Pablo Picasso"
-  },
-  {
-    "quote": "There is no greater agony than bearing an untold story inside you.",
-    "author": "Maya Angelou,  I Know Why the Caged Bird Sings"
-  },
-  {
     "quote": "There is no greater agony than bearing an untold story inside you.",
     "author": "Maya Angelou,  I Know Why the Caged Bird Sings"
   },
@@ -2190,14 +2054,6 @@
   {
     "quote": "Whenever I feel the need to exercise, I lie down until it goes away.",
     "author": "Paul Terry"
-  },
-  {
-    "quote": "I'm not afraid of death; I just don't want to be there when it happens.",
-    "author": "Woody Allen"
-  },
-  {
-    "quote": "I'm not afraid of death; I just don't want to be there when it happens.",
-    "author": "Woody Allen"
   },
   {
     "quote": "I'm not afraid of death; I just don't want to be there when it happens.",
@@ -2280,10 +2136,6 @@
     "author": "C.S. Lewis"
   },
   {
-    "quote": "You can never get a cup of tea large enough or a book long enough to suit me.",
-    "author": "C.S. Lewis"
-  },
-  {
     "quote": "If one cannot enjoy reading a book over and over again, there is no use in reading it at all.",
     "author": "Oscar Wilde"
   },
@@ -2308,14 +2160,6 @@
     "author": "J.K. Rowling,  Harry Potter and the Sorcerer's Stone"
   },
   {
-    "quote": "To the well-organized mind, death is but the next great adventure.",
-    "author": "J.K. Rowling,  Harry Potter and the Sorcerer's Stone"
-  },
-  {
-    "quote": "Listen to the mustn'ts, child. Listen to the don'ts. Listen to the shouldn'ts, the impossibles, the won'ts. Listen to the never haves, then listen close to me... Anything can happen, child. Anything can be.",
-    "author": "Shel Silverstein"
-  },
-  {
     "quote": "Listen to the mustn'ts, child. Listen to the don'ts. Listen to the shouldn'ts, the impossibles, the won'ts. Listen to the never haves, then listen close to me... Anything can happen, child. Anything can be.",
     "author": "Shel Silverstein"
   },
@@ -2328,16 +2172,8 @@
     "author": "Groucho Marx"
   },
   {
-    "quote": "I find television very educating. Every time somebody turns on the set, I go into the other room and read a book.",
-    "author": "Groucho Marx"
-  },
-  {
     "quote": "When one door of happiness closes, another opens; but often we look so long at the closed door that we do not see the one which has been opened for us.",
     "author": "Helen Keller"
-  },
-  {
-    "quote": "Life isn't about finding yourself. Life is about creating yourself.",
-    "author": "George Bernard Shaw"
   },
   {
     "quote": "Life isn't about finding yourself. Life is about creating yourself.",
@@ -2366,10 +2202,6 @@
   {
     "quote": "Some infinities are bigger than other infinities.",
     "author": "John Green,  The Fault in Our Stars"
-  },
-  {
-    "quote": "Love never dies a natural death. It dies because we don't know how to replenish its source. It dies of blindness and errors and betrayals. It dies of illness and wounds; it dies of weariness, of witherings, of tarnishings.",
-    "author": "Ana\u00efs Nin"
   },
   {
     "quote": "Love never dies a natural death. It dies because we don't know how to replenish its source. It dies of blindness and errors and betrayals. It dies of illness and wounds; it dies of weariness, of witherings, of tarnishings.",
@@ -2428,14 +2260,6 @@
     "author": "Bill Watterson,  The Complete Calvin and Hobbes"
   },
   {
-    "quote": "Reality continues to ruin my life.",
-    "author": "Bill Watterson,  The Complete Calvin and Hobbes"
-  },
-  {
-    "quote": "Success is not final, failure is not fatal: it is the courage to continue that counts.",
-    "author": "Winston S. Churchill"
-  },
-  {
     "quote": "Success is not final, failure is not fatal: it is the courage to continue that counts.",
     "author": "Winston S. Churchill"
   },
@@ -2476,24 +2300,12 @@
     "author": "Benjamin Franklin Wade"
   },
   {
-    "quote": "Go to heaven for the climate and hell for the company.",
-    "author": "Benjamin Franklin Wade"
-  },
-  {
-    "quote": "The reason I talk to myself is because I\u2019m the only one whose answers I accept.",
-    "author": "George Carlin"
-  },
-  {
     "quote": "The reason I talk to myself is because I\u2019m the only one whose answers I accept.",
     "author": "George Carlin"
   },
   {
     "quote": "I am free of all prejudice. I hate everyone equally.",
     "author": "W.C. Fields"
-  },
-  {
-    "quote": "What really knocks me out is a book that, when you're all done reading it, you wish the author that wrote it was a terrific friend of yours and you could call him up on the phone whenever you felt like it. That doesn't happen much, though.",
-    "author": "J.D. Salinger,  The Catcher in the Rye"
   },
   {
     "quote": "What really knocks me out is a book that, when you're all done reading it, you wish the author that wrote it was a terrific friend of yours and you could call him up on the phone whenever you felt like it. That doesn't happen much, though.",
@@ -2514,10 +2326,6 @@
   {
     "quote": "Humor is something that thrives between man's aspirations and his limitations. There is more logic in humor than in anything else. Because, you see, humor is truth.",
     "author": "Victor Borge"
-  },
-  {
-    "quote": "Literature is the art of discovering something extraordinary about ordinary people, and saying with ordinary words something extraordinary.",
-    "author": "Boris Pasternak"
   },
   {
     "quote": "Literature is the art of discovering something extraordinary about ordinary people, and saying with ordinary words something extraordinary.",
@@ -2558,10 +2366,6 @@
   {
     "quote": "Life is a gift, given in trust - like a child.",
     "author": "Anne Morrow Lindbergh"
-  },
-  {
-    "quote": "Where there is love there is life.",
-    "author": "Mahatma Gandhi"
   },
   {
     "quote": "Where there is love there is life.",
@@ -2616,10 +2420,6 @@
     "author": "Victor Hugo"
   },
   {
-    "quote": "Life is the flower for which love is the honey.",
-    "author": "Victor Hugo"
-  },
-  {
     "quote": "The best way to make your audience laugh is to start laughing yourself.",
     "author": "Oliver Goldsmith"
   },
@@ -2664,20 +2464,12 @@
     "author": "Emily Dickinson"
   },
   {
-    "quote": "To live is so startling it leaves little time for anything else.",
-    "author": "Emily Dickinson"
-  },
-  {
     "quote": "You can search throughout the entire universe for someone who is more deserving of your love and affection than you are yourself, and that person is not to be found anywhere. You yourself, as much as anybody in the entire universe deserve your love and affection.",
     "author": "Buddha"
   },
   {
     "quote": "There seems to be no lengths to which humorless people will not go to analyze humor. It seems to worry them.",
     "author": "Robert Benchley"
-  },
-  {
-    "quote": "People discuss my art and pretend to understand as if it were necessary to understand, when it's simply necessary to love.",
-    "author": "Claude Monet"
   },
   {
     "quote": "People discuss my art and pretend to understand as if it were necessary to understand, when it's simply necessary to love.",
@@ -2696,14 +2488,6 @@
     "author": "Woody Allen"
   },
   {
-    "quote": "Seventy percent of success in life is showing up.",
-    "author": "Woody Allen"
-  },
-  {
-    "quote": "We're born alone, we live alone, we die alone. Only through our love and friendship can we create the illusion for the moment that we're not alone.",
-    "author": "Orson Welles"
-  },
-  {
     "quote": "We're born alone, we live alone, we die alone. Only through our love and friendship can we create the illusion for the moment that we're not alone.",
     "author": "Orson Welles"
   },
@@ -2720,36 +2504,8 @@
     "author": "Jess C. Scott,  The Intern"
   },
   {
-    "quote": "When someone loves you, the way they talk about you is different. You feel safe and comfortable.",
-    "author": "Jess C. Scott,  The Intern"
-  },
-  {
-    "quote": "When someone loves you, the way they talk about you is different. You feel safe and comfortable.",
-    "author": "Jess C. Scott,  The Intern"
-  },
-  {
-    "quote": "When someone loves you, the way they talk about you is different. You feel safe and comfortable.",
-    "author": "Jess C. Scott,  The Intern"
-  },
-  {
-    "quote": "When someone loves you, the way they talk about you is different. You feel safe and comfortable.",
-    "author": "Jess C. Scott,  The Intern"
-  },
-  {
-    "quote": "When someone loves you, the way they talk about you is different. You feel safe and comfortable.",
-    "author": "Jess C. Scott,  The Intern"
-  },
-  {
     "quote": "When love and skill work together, expect a masterpiece.",
     "author": "John Ruskin"
-  },
-  {
-    "quote": "When love and skill work together, expect a masterpiece.",
-    "author": "John Ruskin"
-  },
-  {
-    "quote": "Easter is meant to be a symbol of hope, renewal, and new life.",
-    "author": "Janine di Giovanni"
   },
   {
     "quote": "Easter is meant to be a symbol of hope, renewal, and new life.",
@@ -2780,10 +2536,6 @@
     "author": "Ravi Zacharias"
   },
   {
-    "quote": "Outside of the cross of Jesus Christ, there is no hope in this world. That cross and resurrection at the core of the Gospel is the only hope for humanity. Wherever you go, ask God for wisdom on how to get that Gospel in, even in the toughest situations of life.",
-    "author": "Ravi Zacharias"
-  },
-  {
     "quote": "Any life is made up of a single moment, the moment in which a man finds out, once and for all, who he is.",
     "author": "Jorge Luis Borges"
   },
@@ -2808,14 +2560,6 @@
     "author": "Bradley Whitford"
   },
   {
-    "quote": "Infuse your life with action. Don't wait for it to happen. Make it happen. Make your own future. Make your own hope. Make your own love. And whatever your beliefs, honor your creator, not by passively waiting for grace to come down from upon high, but by doing what you can to make grace happen... yourself, right now, right down here on Earth.",
-    "author": "Bradley Whitford"
-  },
-  {
-    "quote": "Infuse your life with action. Don't wait for it to happen. Make it happen. Make your own future. Make your own hope. Make your own love. And whatever your beliefs, honor your creator, not by passively waiting for grace to come down from upon high, but by doing what you can to make grace happen... yourself, right now, right down here on Earth.",
-    "author": "Bradley Whitford"
-  },
-  {
     "quote": "Wrong life cannot be lived rightly.",
     "author": "Theodor Adorno"
   },
@@ -2826,10 +2570,6 @@
   {
     "quote": "It is the ability to take a joke, not make one, that proves you have a sense of humor.",
     "author": "Max Eastman"
-  },
-  {
-    "quote": "Every bit of me is devoted to love and art. And I aspire to try to be a teacher to my young fans who feel just like I felt when I was younger. I just felt like a freak. I guess what I'm trying to say is I'm trying to liberate them, I want to free them of their fears and make them feel that they can make their own space in the world.",
-    "author": "Lady Gaga"
   },
   {
     "quote": "Every bit of me is devoted to love and art. And I aspire to try to be a teacher to my young fans who feel just like I felt when I was younger. I just felt like a freak. I guess what I'm trying to say is I'm trying to liberate them, I want to free them of their fears and make them feel that they can make their own space in the world.",
@@ -2872,10 +2612,6 @@
     "author": "John Lennon"
   },
   {
-    "quote": "You may say I'm a dreamer, but I'm not the only one. I hope someday you'll join us. And the world will live as one.",
-    "author": "John Lennon"
-  },
-  {
     "quote": "To be successful, you have to have your heart in your business and your business in your heart.",
     "author": "Thomas J. Watson"
   },
@@ -2886,14 +2622,6 @@
   {
     "quote": "The greatest trap in our life is not success, popularity or power, but self-rejection.",
     "author": "Henri Nouwen"
-  },
-  {
-    "quote": "The greatest trap in our life is not success, popularity or power, but self-rejection.",
-    "author": "Henri Nouwen"
-  },
-  {
-    "quote": "We love life, not because we are used to living but because we are used to loving.",
-    "author": "Friedrich Nietzsche"
   },
   {
     "quote": "We love life, not because we are used to living but because we are used to loving.",
@@ -2940,10 +2668,6 @@
     "author": "Basil Hume"
   },
   {
-    "quote": "The great gift of Easter is hope - Christian hope which makes us have that confidence in God, in his ultimate triumph, and in his goodness and love, which nothing can shake.",
-    "author": "Basil Hume"
-  },
-  {
     "quote": "Life consists not in holding good cards but in playing those you hold well.",
     "author": "Josh Billings"
   },
@@ -2958,10 +2682,6 @@
   {
     "quote": "Where thou art, that is home.",
     "author": "Emily Dickinson"
-  },
-  {
-    "quote": "Formal education will make you a living; self-education will make you a fortune.",
-    "author": "Jim Rohn"
   },
   {
     "quote": "Formal education will make you a living; self-education will make you a fortune.",
@@ -3020,10 +2740,6 @@
     "author": "Brad Henry"
   },
   {
-    "quote": "A good teacher can inspire hope, ignite the imagination, and instill a love of learning.",
-    "author": "Brad Henry"
-  },
-  {
     "quote": "Fortunately analysis is not the only way to resolve inner conflicts. Life itself still remains a very effective therapist.",
     "author": "Karen Horney"
   },
@@ -3060,10 +2776,6 @@
     "author": "Robert Fulghum"
   },
   {
-    "quote": "I believe that imagination is stronger than knowledge. That myth is more potent than history. That dreams are more powerful than facts. That hope always triumphs over experience. That laughter is the only cure for grief. And I believe that love is stronger than death.",
-    "author": "Robert Fulghum"
-  },
-  {
     "quote": "Laughter is involuntary. If it's funny you laugh.",
     "author": "Tom Lehrer"
   },
@@ -3074,10 +2786,6 @@
   {
     "quote": "Success is finding satisfaction in giving a little more than you take.",
     "author": "Christopher Reeve"
-  },
-  {
-    "quote": "You are not here merely to make a living. You are here in order to enable the world to live more amply, with greater vision, with a finer spirit of hope and achievement. You are here to enrich the world, and you impoverish yourself if you forget the errand.",
-    "author": "Woodrow Wilson"
   },
   {
     "quote": "You are not here merely to make a living. You are here in order to enable the world to live more amply, with greater vision, with a finer spirit of hope and achievement. You are here to enrich the world, and you impoverish yourself if you forget the errand.",
@@ -3118,10 +2826,6 @@
   {
     "quote": "A sense of humor is the ability to understand a joke - and that the joke is oneself.",
     "author": "Clifton Fadiman"
-  },
-  {
-    "quote": "Perhaps it's good for one to suffer. Can an artist do anything if he's happy? Would he ever want to do anything? What is art, after all, but a protest against the horrible inclemency of life?",
-    "author": "Aldous Huxley"
   },
   {
     "quote": "Perhaps it's good for one to suffer. Can an artist do anything if he's happy? Would he ever want to do anything? What is art, after all, but a protest against the horrible inclemency of life?",
@@ -3182,14 +2886,6 @@
   {
     "quote": "If you want to achieve things in life, you've just got to do them, and if you're talented and smart, you'll succeed.",
     "author": "Juliana Hatfield"
-  },
-  {
-    "quote": "If you want to achieve things in life, you've just got to do them, and if you're talented and smart, you'll succeed.",
-    "author": "Juliana Hatfield"
-  },
-  {
-    "quote": "Imagine all the people living life in peace. You may say I'm a dreamer, but I'm not the only one. I hope someday you'll join us, and the world will be as one.",
-    "author": "John Lennon"
   },
   {
     "quote": "Imagine all the people living life in peace. You may say I'm a dreamer, but I'm not the only one. I hope someday you'll join us, and the world will be as one.",
@@ -3428,10 +3124,6 @@
     "author": "David Frost"
   },
   {
-    "quote": "Don't aim for success if you want it; just do what you love and believe in, and it will come naturally.",
-    "author": "David Frost"
-  },
-  {
     "quote": "A lot of people, to attack an outspoken atheist, one of the things they'll do is say, 'You are as bad as the fundamentalist Christians.' And my answer is always, 'I hope so.'",
     "author": "Penn Jillette"
   },
@@ -3462,10 +3154,6 @@
   {
     "quote": "You want to play another kind of character in another genre, and it's been something I've been trying to do if I can in the career so far, and it's something I hope to continue because it's interesting to me and you get to do different things as an actor.",
     "author": "Keanu Reeves"
-  },
-  {
-    "quote": "Hold fast to dreams, for if dreams die, life is a broken-winged bird that cannot fly.",
-    "author": "Langston Hughes"
   },
   {
     "quote": "Hold fast to dreams, for if dreams die, life is a broken-winged bird that cannot fly.",
@@ -3556,14 +3244,6 @@
     "author": "A. P. J. Abdul Kalam"
   },
   {
-    "quote": "The bird is powered by its own life and by its motivation.",
-    "author": "A. P. J. Abdul Kalam"
-  },
-  {
-    "quote": "The bird is powered by its own life and by its motivation.",
-    "author": "A. P. J. Abdul Kalam"
-  },
-  {
     "quote": "Every artist dips his brush in his own soul, and paints his own nature into his pictures.",
     "author": "Henry Ward Beecher"
   },
@@ -3586,10 +3266,6 @@
   {
     "quote": "I'm quite a confident person in many ways, but there's only so much you can hear about being compared to Hattie Jacques. For the record, she was a comedy goddess, but she was 25 stone. I hope I'm right in saying I'm not in any way nearly 25 stone.",
     "author": "Miranda Hart"
-  },
-  {
-    "quote": "The fear of death follows from the fear of life. A man who lives fully is prepared to die at any time.",
-    "author": "Mark Twain"
   },
   {
     "quote": "The fear of death follows from the fear of life. A man who lives fully is prepared to die at any time.",
@@ -3636,10 +3312,6 @@
     "author": "Jimi Hendrix,  Jimi Hendrix - Axis: Bold as Love"
   },
   {
-    "quote": "I'm the one that's got to die when it's time for me to die, so let me live my life the way I want to.",
-    "author": "Jimi Hendrix,  Jimi Hendrix - Axis: Bold as Love"
-  },
-  {
     "quote": "Winning isn't everything, it's the only thing.",
     "author": "Vince Lombardi"
   },
@@ -3666,10 +3338,6 @@
   {
     "quote": "\u2032Classic\u2032 - a book which people praise and don't read.",
     "author": "Mark Twain"
-  },
-  {
-    "quote": "Take up one idea. Make that one idea your life - think of it, dream of it, live on that idea. Let the brain, muscles, nerves, every part of your body, be full of that idea, and just leave every other idea alone. This is the way to success.",
-    "author": "Swami Vivekananda"
   },
   {
     "quote": "Take up one idea. Make that one idea your life - think of it, dream of it, live on that idea. Let the brain, muscles, nerves, every part of your body, be full of that idea, and just leave every other idea alone. This is the way to success.",
@@ -3708,36 +3376,12 @@
     "author": "Sundar Pichai"
   },
   {
-    "quote": "Don't cry because it's over, smile because it happened.",
-    "author": "Dr. Seuss"
-  },
-  {
-    "quote": "Don't cry because it's over, smile because it happened.",
-    "author": "Dr. Seuss"
-  },
-  {
-    "quote": "I'm selfish, impatient and a little insecure. I make mistakes, I am out of control and at times hard to handle. But if you can't handle me at my worst, then you sure as hell don't deserve me at my best.",
-    "author": "Marilyn Monroe"
-  },
-  {
-    "quote": "I'm selfish, impatient and a little insecure. I make mistakes, I am out of control and at times hard to handle. But if you can't handle me at my worst, then you sure as hell don't deserve me at my best.",
-    "author": "Marilyn Monroe"
-  },
-  {
     "quote": "I'm selfish, impatient and a little insecure. I make mistakes, I am out of control and at times hard to handle. But if you can't handle me at my worst, then you sure as hell don't deserve me at my best.",
     "author": "Marilyn Monroe"
   },
   {
     "quote": "Be yourself; everyone else is already taken.",
     "author": "Oscar Wilde"
-  },
-  {
-    "quote": "Two things are infinite: the universe and human stupidity; and I'm not sure about the universe.",
-    "author": "Albert Einstein"
-  },
-  {
-    "quote": "Two things are infinite: the universe and human stupidity; and I'm not sure about the universe.",
-    "author": "Albert Einstein"
   },
   {
     "quote": "Two things are infinite: the universe and human stupidity; and I'm not sure about the universe.",
@@ -3752,14 +3396,6 @@
     "author": "William W. Purkey"
   },
   {
-    "quote": "You've gotta dance like there's nobody watching,Love like you'll never be hurt,Sing like there's nobody listening,And live like it's heaven on earth.",
-    "author": "William W. Purkey"
-  },
-  {
-    "quote": "You've gotta dance like there's nobody watching,Love like you'll never be hurt,Sing like there's nobody listening,And live like it's heaven on earth.",
-    "author": "William W. Purkey"
-  },
-  {
     "quote": "You know you're in love when you can't fall asleep because reality is finally better than your dreams.",
     "author": "Dr. Seuss"
   },
@@ -3768,28 +3404,12 @@
     "author": "Marcus Tullius Cicero"
   },
   {
-    "quote": "A room without books is like a body without a soul.",
-    "author": "Marcus Tullius Cicero"
-  },
-  {
-    "quote": "So many books, so little time.",
-    "author": "Frank Zappa"
-  },
-  {
     "quote": "So many books, so little time.",
     "author": "Frank Zappa"
   },
   {
     "quote": "You only live once, but if you do it right, once is enough.",
     "author": "Mae West"
-  },
-  {
-    "quote": "You only live once, but if you do it right, once is enough.",
-    "author": "Mae West"
-  },
-  {
-    "quote": "Be the change that you wish to see in the world.",
-    "author": "Mahatma Gandhi"
   },
   {
     "quote": "Be the change that you wish to see in the world.",
@@ -3816,16 +3436,8 @@
     "author": "Eleanor Roosevelt,  This is My Story"
   },
   {
-    "quote": "No one can make you feel inferior without your consent.",
-    "author": "Eleanor Roosevelt,  This is My Story"
-  },
-  {
     "quote": "If you tell the truth, you don't have to remember anything.",
     "author": "Mark Twain"
-  },
-  {
-    "quote": "A friend is someone who knows all about you and still loves you.",
-    "author": "Elbert Hubbard"
   },
   {
     "quote": "A friend is someone who knows all about you and still loves you.",
@@ -3844,16 +3456,8 @@
     "author": "Mahatma Gandhi"
   },
   {
-    "quote": "Live as if you were to die tomorrow. Learn as if you were to live forever.",
-    "author": "Mahatma Gandhi"
-  },
-  {
     "quote": "I am so clever that sometimes I don't understand a single word of what I am saying.",
     "author": "Oscar Wilde,  The Happy Prince and Other Stories"
-  },
-  {
-    "quote": "Darkness cannot drive out darkness: only light can do that. Hate cannot drive out hate: only love can do that.",
-    "author": "Martin Luther King Jr.,  A Testament of Hope: The Essential Writings and Speeches"
   },
   {
     "quote": "Darkness cannot drive out darkness: only light can do that. Hate cannot drive out hate: only love can do that.",
@@ -3866,14 +3470,6 @@
   {
     "quote": "Without music, life would be a mistake.",
     "author": "Friedrich Nietzsche,  Twilight of the Idols"
-  },
-  {
-    "quote": "Without music, life would be a mistake.",
-    "author": "Friedrich Nietzsche,  Twilight of the Idols"
-  },
-  {
-    "quote": "Insanity is doing the same thing, over and over again, but expecting different results.",
-    "author": "Narcotics Anonymous"
   },
   {
     "quote": "Insanity is doing the same thing, over and over again, but expecting different results.",
@@ -3896,14 +3492,6 @@
     "author": "Stephen Chbosky,  The Perks of Being a Wallflower"
   },
   {
-    "quote": "We accept the love we think we deserve.",
-    "author": "Stephen Chbosky,  The Perks of Being a Wallflower"
-  },
-  {
-    "quote": "It is better to be hated for what you are than to be loved for what you are not.",
-    "author": "Andr\u00e9 Gide,  Autumn Leaves"
-  },
-  {
     "quote": "It is better to be hated for what you are than to be loved for what you are not.",
     "author": "Andr\u00e9 Gide,  Autumn Leaves"
   },
@@ -3918,14 +3506,6 @@
   {
     "quote": "The person, be it gentleman or lady, who has not pleasure in a good novel, must be intolerably stupid.",
     "author": "Jane Austen,  Northanger Abbey"
-  },
-  {
-    "quote": "The person, be it gentleman or lady, who has not pleasure in a good novel, must be intolerably stupid.",
-    "author": "Jane Austen,  Northanger Abbey"
-  },
-  {
-    "quote": "There are only two ways to live your life. One is as though nothing is a miracle. The other is as though everything is a miracle.",
-    "author": "Albert Einstein"
   },
   {
     "quote": "There are only two ways to live your life. One is as though nothing is a miracle. The other is as though everything is a miracle.",
@@ -3952,10 +3532,6 @@
     "author": "Mark Twain"
   },
   {
-    "quote": "Good friends, good books, and a sleepy conscience: this is the ideal life.",
-    "author": "Mark Twain"
-  },
-  {
     "quote": "Whenever you find yourself on the side of the majority, it is time to reform (or pause and reflect).",
     "author": "Mark Twain"
   },
@@ -3970,10 +3546,6 @@
   {
     "quote": "A woman is like a tea bag; you never know how strong it is until it's in hot water.",
     "author": "Eleanor Roosevelt"
-  },
-  {
-    "quote": "Yesterday is history, tomorrow is a mystery, today is a gift of God, which is why we call it the present.",
-    "author": "Bil Keane"
   },
   {
     "quote": "Yesterday is history, tomorrow is a mystery, today is a gift of God, which is why we call it the present.",
@@ -4000,32 +3572,8 @@
     "author": "Friedrich Nietzsche"
   },
   {
-    "quote": "It is not a lack of love, but a lack of friendship that makes unhappy marriages.",
-    "author": "Friedrich Nietzsche"
-  },
-  {
     "quote": "The opposite of love is not hate, it's indifference. The opposite of art is not ugliness, it's indifference. The opposite of faith is not heresy, it's indifference. And the opposite of life is not death, it's indifference.",
     "author": "Elie Wiesel"
-  },
-  {
-    "quote": "The opposite of love is not hate, it's indifference. The opposite of art is not ugliness, it's indifference. The opposite of faith is not heresy, it's indifference. And the opposite of life is not death, it's indifference.",
-    "author": "Elie Wiesel"
-  },
-  {
-    "quote": "The opposite of love is not hate, it's indifference. The opposite of art is not ugliness, it's indifference. The opposite of faith is not heresy, it's indifference. And the opposite of life is not death, it's indifference.",
-    "author": "Elie Wiesel"
-  },
-  {
-    "quote": "Fairy tales are more than true: not because they tell us that dragons exist, but because they tell us that dragons can be beaten.",
-    "author": "Neil Gaiman,  Coraline"
-  },
-  {
-    "quote": "Fairy tales are more than true: not because they tell us that dragons exist, but because they tell us that dragons can be beaten.",
-    "author": "Neil Gaiman,  Coraline"
-  },
-  {
-    "quote": "Outside of a dog, a book is man's best friend. Inside of a dog it's too dark to read.",
-    "author": "Groucho Marx,  The Essential Groucho: Writings For By And About Groucho Marx"
   },
   {
     "quote": "Outside of a dog, a book is man's best friend. Inside of a dog it's too dark to read.",
@@ -4050,10 +3598,6 @@
   {
     "quote": "Never put off till tomorrow what may be done day after tomorrow just as well.",
     "author": "Mark Twain"
-  },
-  {
-    "quote": "I love you without knowing how, or when, or from where. I love you simply, without problems or pride: I love you in this way because I do not know any other way of loving but this, in which there is no I or you, so intimate that your hand upon my chest is my hand, so intimate that when I fall asleep your eyes close.",
-    "author": "Pablo Neruda,  100 Love Sonnets"
   },
   {
     "quote": "I love you without knowing how, or when, or from where. I love you simply, without problems or pride: I love you in this way because I do not know any other way of loving but this, in which there is no I or you, so intimate that your hand upon my chest is my hand, so intimate that when I fall asleep your eyes close.",
@@ -4104,16 +3648,8 @@
     "author": "Douglas Adams,  The Salmon of Doubt"
   },
   {
-    "quote": "I love deadlines. I love the whooshing noise they make as they go by.",
-    "author": "Douglas Adams,  The Salmon of Doubt"
-  },
-  {
     "quote": "It is never too late to be what you might have been.",
     "author": "George Eliot"
-  },
-  {
-    "quote": "Anyone who thinks sitting in church can make you a Christian must also think that sitting in a garage can make you a car.",
-    "author": "Garrison Keillor"
   },
   {
     "quote": "Anyone who thinks sitting in church can make you a Christian must also think that sitting in a garage can make you a car.",
@@ -4138,10 +3674,6 @@
   {
     "quote": "It takes a great deal of bravery to stand up to our enemies, but just as much to stand up to our friends.",
     "author": "J.K. Rowling,  Harry Potter and the Sorcerer's Stone"
-  },
-  {
-    "quote": "Love is that condition in which the happiness of another person is essential to your own.",
-    "author": "Robert A. Heinlein,  Stranger in a Strange Land"
   },
   {
     "quote": "Love is that condition in which the happiness of another person is essential to your own.",
@@ -4180,14 +3712,6 @@
     "author": "Pablo Picasso"
   },
   {
-    "quote": "Everything you can imagine is real.",
-    "author": "Pablo Picasso"
-  },
-  {
-    "quote": "There is no greater agony than bearing an untold story inside you.",
-    "author": "Maya Angelou,  I Know Why the Caged Bird Sings"
-  },
-  {
     "quote": "There is no greater agony than bearing an untold story inside you.",
     "author": "Maya Angelou,  I Know Why the Caged Bird Sings"
   },
@@ -4206,14 +3730,6 @@
   {
     "quote": "Whenever I feel the need to exercise, I lie down until it goes away.",
     "author": "Paul Terry"
-  },
-  {
-    "quote": "I'm not afraid of death; I just don't want to be there when it happens.",
-    "author": "Woody Allen"
-  },
-  {
-    "quote": "I'm not afraid of death; I just don't want to be there when it happens.",
-    "author": "Woody Allen"
   },
   {
     "quote": "I'm not afraid of death; I just don't want to be there when it happens.",
@@ -4300,10 +3816,6 @@
     "author": "C.S. Lewis"
   },
   {
-    "quote": "You can never get a cup of tea large enough or a book long enough to suit me.",
-    "author": "C.S. Lewis"
-  },
-  {
     "quote": "If one cannot enjoy reading a book over and over again, there is no use in reading it at all.",
     "author": "Oscar Wilde"
   },
@@ -4328,14 +3840,6 @@
     "author": "J.K. Rowling,  Harry Potter and the Sorcerer's Stone"
   },
   {
-    "quote": "To the well-organized mind, death is but the next great adventure.",
-    "author": "J.K. Rowling,  Harry Potter and the Sorcerer's Stone"
-  },
-  {
-    "quote": "Listen to the mustn'ts, child. Listen to the don'ts. Listen to the shouldn'ts, the impossibles, the won'ts. Listen to the never haves, then listen close to me... Anything can happen, child. Anything can be.",
-    "author": "Shel Silverstein"
-  },
-  {
     "quote": "Listen to the mustn'ts, child. Listen to the don'ts. Listen to the shouldn'ts, the impossibles, the won'ts. Listen to the never haves, then listen close to me... Anything can happen, child. Anything can be.",
     "author": "Shel Silverstein"
   },
@@ -4348,16 +3852,8 @@
     "author": "Groucho Marx"
   },
   {
-    "quote": "I find television very educating. Every time somebody turns on the set, I go into the other room and read a book.",
-    "author": "Groucho Marx"
-  },
-  {
     "quote": "When one door of happiness closes, another opens; but often we look so long at the closed door that we do not see the one which has been opened for us.",
     "author": "Helen Keller"
-  },
-  {
-    "quote": "Life isn't about finding yourself. Life is about creating yourself.",
-    "author": "George Bernard Shaw"
   },
   {
     "quote": "Life isn't about finding yourself. Life is about creating yourself.",
@@ -4386,10 +3882,6 @@
   {
     "quote": "Some infinities are bigger than other infinities.",
     "author": "John Green,  The Fault in Our Stars"
-  },
-  {
-    "quote": "Love never dies a natural death. It dies because we don't know how to replenish its source. It dies of blindness and errors and betrayals. It dies of illness and wounds; it dies of weariness, of witherings, of tarnishings.",
-    "author": "Ana\u00efs Nin"
   },
   {
     "quote": "Love never dies a natural death. It dies because we don't know how to replenish its source. It dies of blindness and errors and betrayals. It dies of illness and wounds; it dies of weariness, of witherings, of tarnishings.",
@@ -4448,14 +3940,6 @@
     "author": "Bill Watterson,  The Complete Calvin and Hobbes"
   },
   {
-    "quote": "Reality continues to ruin my life.",
-    "author": "Bill Watterson,  The Complete Calvin and Hobbes"
-  },
-  {
-    "quote": "Success is not final, failure is not fatal: it is the courage to continue that counts.",
-    "author": "Winston S. Churchill"
-  },
-  {
     "quote": "Success is not final, failure is not fatal: it is the courage to continue that counts.",
     "author": "Winston S. Churchill"
   },
@@ -4496,24 +3980,12 @@
     "author": "Benjamin Franklin Wade"
   },
   {
-    "quote": "Go to heaven for the climate and hell for the company.",
-    "author": "Benjamin Franklin Wade"
-  },
-  {
-    "quote": "The reason I talk to myself is because I\u2019m the only one whose answers I accept.",
-    "author": "George Carlin"
-  },
-  {
     "quote": "The reason I talk to myself is because I\u2019m the only one whose answers I accept.",
     "author": "George Carlin"
   },
   {
     "quote": "I am free of all prejudice. I hate everyone equally.",
     "author": "W.C. Fields"
-  },
-  {
-    "quote": "What really knocks me out is a book that, when you're all done reading it, you wish the author that wrote it was a terrific friend of yours and you could call him up on the phone whenever you felt like it. That doesn't happen much, though.",
-    "author": "J.D. Salinger,  The Catcher in the Rye"
   },
   {
     "quote": "What really knocks me out is a book that, when you're all done reading it, you wish the author that wrote it was a terrific friend of yours and you could call him up on the phone whenever you felt like it. That doesn't happen much, though.",
@@ -4534,10 +4006,6 @@
   {
     "quote": "Humor is something that thrives between man's aspirations and his limitations. There is more logic in humor than in anything else. Because, you see, humor is truth.",
     "author": "Victor Borge"
-  },
-  {
-    "quote": "Literature is the art of discovering something extraordinary about ordinary people, and saying with ordinary words something extraordinary.",
-    "author": "Boris Pasternak"
   },
   {
     "quote": "Literature is the art of discovering something extraordinary about ordinary people, and saying with ordinary words something extraordinary.",
@@ -4578,10 +4046,6 @@
   {
     "quote": "Life is a gift, given in trust - like a child.",
     "author": "Anne Morrow Lindbergh"
-  },
-  {
-    "quote": "Where there is love there is life.",
-    "author": "Mahatma Gandhi"
   },
   {
     "quote": "Where there is love there is life.",
@@ -4636,10 +4100,6 @@
     "author": "Victor Hugo"
   },
   {
-    "quote": "Life is the flower for which love is the honey.",
-    "author": "Victor Hugo"
-  },
-  {
     "quote": "The best way to make your audience laugh is to start laughing yourself.",
     "author": "Oliver Goldsmith"
   },
@@ -4684,20 +4144,12 @@
     "author": "Emily Dickinson"
   },
   {
-    "quote": "To live is so startling it leaves little time for anything else.",
-    "author": "Emily Dickinson"
-  },
-  {
     "quote": "You can search throughout the entire universe for someone who is more deserving of your love and affection than you are yourself, and that person is not to be found anywhere. You yourself, as much as anybody in the entire universe deserve your love and affection.",
     "author": "Buddha"
   },
   {
     "quote": "There seems to be no lengths to which humorless people will not go to analyze humor. It seems to worry them.",
     "author": "Robert Benchley"
-  },
-  {
-    "quote": "People discuss my art and pretend to understand as if it were necessary to understand, when it's simply necessary to love.",
-    "author": "Claude Monet"
   },
   {
     "quote": "People discuss my art and pretend to understand as if it were necessary to understand, when it's simply necessary to love.",
@@ -4716,14 +4168,6 @@
     "author": "Woody Allen"
   },
   {
-    "quote": "Seventy percent of success in life is showing up.",
-    "author": "Woody Allen"
-  },
-  {
-    "quote": "We're born alone, we live alone, we die alone. Only through our love and friendship can we create the illusion for the moment that we're not alone.",
-    "author": "Orson Welles"
-  },
-  {
     "quote": "We're born alone, we live alone, we die alone. Only through our love and friendship can we create the illusion for the moment that we're not alone.",
     "author": "Orson Welles"
   },
@@ -4740,36 +4184,8 @@
     "author": "Jess C. Scott,  The Intern"
   },
   {
-    "quote": "When someone loves you, the way they talk about you is different. You feel safe and comfortable.",
-    "author": "Jess C. Scott,  The Intern"
-  },
-  {
-    "quote": "When someone loves you, the way they talk about you is different. You feel safe and comfortable.",
-    "author": "Jess C. Scott,  The Intern"
-  },
-  {
-    "quote": "When someone loves you, the way they talk about you is different. You feel safe and comfortable.",
-    "author": "Jess C. Scott,  The Intern"
-  },
-  {
-    "quote": "When someone loves you, the way they talk about you is different. You feel safe and comfortable.",
-    "author": "Jess C. Scott,  The Intern"
-  },
-  {
-    "quote": "When someone loves you, the way they talk about you is different. You feel safe and comfortable.",
-    "author": "Jess C. Scott,  The Intern"
-  },
-  {
     "quote": "When love and skill work together, expect a masterpiece.",
     "author": "John Ruskin"
-  },
-  {
-    "quote": "When love and skill work together, expect a masterpiece.",
-    "author": "John Ruskin"
-  },
-  {
-    "quote": "Easter is meant to be a symbol of hope, renewal, and new life.",
-    "author": "Janine di Giovanni"
   },
   {
     "quote": "Easter is meant to be a symbol of hope, renewal, and new life.",
@@ -4800,10 +4216,6 @@
     "author": "Ravi Zacharias"
   },
   {
-    "quote": "Outside of the cross of Jesus Christ, there is no hope in this world. That cross and resurrection at the core of the Gospel is the only hope for humanity. Wherever you go, ask God for wisdom on how to get that Gospel in, even in the toughest situations of life.",
-    "author": "Ravi Zacharias"
-  },
-  {
     "quote": "Any life is made up of a single moment, the moment in which a man finds out, once and for all, who he is.",
     "author": "Jorge Luis Borges"
   },
@@ -4828,14 +4240,6 @@
     "author": "Bradley Whitford"
   },
   {
-    "quote": "Infuse your life with action. Don't wait for it to happen. Make it happen. Make your own future. Make your own hope. Make your own love. And whatever your beliefs, honor your creator, not by passively waiting for grace to come down from upon high, but by doing what you can to make grace happen... yourself, right now, right down here on Earth.",
-    "author": "Bradley Whitford"
-  },
-  {
-    "quote": "Infuse your life with action. Don't wait for it to happen. Make it happen. Make your own future. Make your own hope. Make your own love. And whatever your beliefs, honor your creator, not by passively waiting for grace to come down from upon high, but by doing what you can to make grace happen... yourself, right now, right down here on Earth.",
-    "author": "Bradley Whitford"
-  },
-  {
     "quote": "Wrong life cannot be lived rightly.",
     "author": "Theodor Adorno"
   },
@@ -4846,10 +4250,6 @@
   {
     "quote": "It is the ability to take a joke, not make one, that proves you have a sense of humor.",
     "author": "Max Eastman"
-  },
-  {
-    "quote": "Every bit of me is devoted to love and art. And I aspire to try to be a teacher to my young fans who feel just like I felt when I was younger. I just felt like a freak. I guess what I'm trying to say is I'm trying to liberate them, I want to free them of their fears and make them feel that they can make their own space in the world.",
-    "author": "Lady Gaga"
   },
   {
     "quote": "Every bit of me is devoted to love and art. And I aspire to try to be a teacher to my young fans who feel just like I felt when I was younger. I just felt like a freak. I guess what I'm trying to say is I'm trying to liberate them, I want to free them of their fears and make them feel that they can make their own space in the world.",
@@ -4892,10 +4292,6 @@
     "author": "John Lennon"
   },
   {
-    "quote": "You may say I'm a dreamer, but I'm not the only one. I hope someday you'll join us. And the world will live as one.",
-    "author": "John Lennon"
-  },
-  {
     "quote": "To be successful, you have to have your heart in your business and your business in your heart.",
     "author": "Thomas J. Watson"
   },
@@ -4906,14 +4302,6 @@
   {
     "quote": "The greatest trap in our life is not success, popularity or power, but self-rejection.",
     "author": "Henri Nouwen"
-  },
-  {
-    "quote": "The greatest trap in our life is not success, popularity or power, but self-rejection.",
-    "author": "Henri Nouwen"
-  },
-  {
-    "quote": "We love life, not because we are used to living but because we are used to loving.",
-    "author": "Friedrich Nietzsche"
   },
   {
     "quote": "We love life, not because we are used to living but because we are used to loving.",
@@ -4960,10 +4348,6 @@
     "author": "Basil Hume"
   },
   {
-    "quote": "The great gift of Easter is hope - Christian hope which makes us have that confidence in God, in his ultimate triumph, and in his goodness and love, which nothing can shake.",
-    "author": "Basil Hume"
-  },
-  {
     "quote": "Life consists not in holding good cards but in playing those you hold well.",
     "author": "Josh Billings"
   },
@@ -4978,10 +4362,6 @@
   {
     "quote": "Where thou art, that is home.",
     "author": "Emily Dickinson"
-  },
-  {
-    "quote": "Formal education will make you a living; self-education will make you a fortune.",
-    "author": "Jim Rohn"
   },
   {
     "quote": "Formal education will make you a living; self-education will make you a fortune.",
@@ -5040,10 +4420,6 @@
     "author": "Brad Henry"
   },
   {
-    "quote": "A good teacher can inspire hope, ignite the imagination, and instill a love of learning.",
-    "author": "Brad Henry"
-  },
-  {
     "quote": "Fortunately analysis is not the only way to resolve inner conflicts. Life itself still remains a very effective therapist.",
     "author": "Karen Horney"
   },
@@ -5080,10 +4456,6 @@
     "author": "Robert Fulghum"
   },
   {
-    "quote": "I believe that imagination is stronger than knowledge. That myth is more potent than history. That dreams are more powerful than facts. That hope always triumphs over experience. That laughter is the only cure for grief. And I believe that love is stronger than death.",
-    "author": "Robert Fulghum"
-  },
-  {
     "quote": "Laughter is involuntary. If it's funny you laugh.",
     "author": "Tom Lehrer"
   },
@@ -5094,10 +4466,6 @@
   {
     "quote": "Success is finding satisfaction in giving a little more than you take.",
     "author": "Christopher Reeve"
-  },
-  {
-    "quote": "You are not here merely to make a living. You are here in order to enable the world to live more amply, with greater vision, with a finer spirit of hope and achievement. You are here to enrich the world, and you impoverish yourself if you forget the errand.",
-    "author": "Woodrow Wilson"
   },
   {
     "quote": "You are not here merely to make a living. You are here in order to enable the world to live more amply, with greater vision, with a finer spirit of hope and achievement. You are here to enrich the world, and you impoverish yourself if you forget the errand.",
@@ -5138,10 +4506,6 @@
   {
     "quote": "A sense of humor is the ability to understand a joke - and that the joke is oneself.",
     "author": "Clifton Fadiman"
-  },
-  {
-    "quote": "Perhaps it's good for one to suffer. Can an artist do anything if he's happy? Would he ever want to do anything? What is art, after all, but a protest against the horrible inclemency of life?",
-    "author": "Aldous Huxley"
   },
   {
     "quote": "Perhaps it's good for one to suffer. Can an artist do anything if he's happy? Would he ever want to do anything? What is art, after all, but a protest against the horrible inclemency of life?",
@@ -5202,14 +4566,6 @@
   {
     "quote": "If you want to achieve things in life, you've just got to do them, and if you're talented and smart, you'll succeed.",
     "author": "Juliana Hatfield"
-  },
-  {
-    "quote": "If you want to achieve things in life, you've just got to do them, and if you're talented and smart, you'll succeed.",
-    "author": "Juliana Hatfield"
-  },
-  {
-    "quote": "Imagine all the people living life in peace. You may say I'm a dreamer, but I'm not the only one. I hope someday you'll join us, and the world will be as one.",
-    "author": "John Lennon"
   },
   {
     "quote": "Imagine all the people living life in peace. You may say I'm a dreamer, but I'm not the only one. I hope someday you'll join us, and the world will be as one.",
@@ -5448,10 +4804,6 @@
     "author": "David Frost"
   },
   {
-    "quote": "Don't aim for success if you want it; just do what you love and believe in, and it will come naturally.",
-    "author": "David Frost"
-  },
-  {
     "quote": "A lot of people, to attack an outspoken atheist, one of the things they'll do is say, 'You are as bad as the fundamentalist Christians.' And my answer is always, 'I hope so.'",
     "author": "Penn Jillette"
   },
@@ -5482,10 +4834,6 @@
   {
     "quote": "You want to play another kind of character in another genre, and it's been something I've been trying to do if I can in the career so far, and it's something I hope to continue because it's interesting to me and you get to do different things as an actor.",
     "author": "Keanu Reeves"
-  },
-  {
-    "quote": "Hold fast to dreams, for if dreams die, life is a broken-winged bird that cannot fly.",
-    "author": "Langston Hughes"
   },
   {
     "quote": "Hold fast to dreams, for if dreams die, life is a broken-winged bird that cannot fly.",
@@ -5564,20 +4912,8 @@
     "author": "Mario Andretti"
   },
   {
-    "quote": "Desire is the key to motivation, but it's determination and commitment to an unrelenting pursuit of your goal - a commitment to excellence - that will enable you to attain the success you seek.",
-    "author": "Mario Andretti"
-  },
-  {
     "quote": "I have learned from my experiences in this industry that there is absolutely no way to control people's opinions on your performance in your movie. You go out there, promote your film and hope people like the work you did.",
     "author": "Leonardo DiCaprio"
-  },
-  {
-    "quote": "The bird is powered by its own life and by its motivation.",
-    "author": "A. P. J. Abdul Kalam"
-  },
-  {
-    "quote": "The bird is powered by its own life and by its motivation.",
-    "author": "A. P. J. Abdul Kalam"
   },
   {
     "quote": "The bird is powered by its own life and by its motivation.",
@@ -5606,10 +4942,6 @@
   {
     "quote": "I'm quite a confident person in many ways, but there's only so much you can hear about being compared to Hattie Jacques. For the record, she was a comedy goddess, but she was 25 stone. I hope I'm right in saying I'm not in any way nearly 25 stone.",
     "author": "Miranda Hart"
-  },
-  {
-    "quote": "The fear of death follows from the fear of life. A man who lives fully is prepared to die at any time.",
-    "author": "Mark Twain"
   },
   {
     "quote": "The fear of death follows from the fear of life. A man who lives fully is prepared to die at any time.",
@@ -5656,10 +4988,6 @@
     "author": "Jimi Hendrix,  Jimi Hendrix - Axis: Bold as Love"
   },
   {
-    "quote": "I'm the one that's got to die when it's time for me to die, so let me live my life the way I want to.",
-    "author": "Jimi Hendrix,  Jimi Hendrix - Axis: Bold as Love"
-  },
-  {
     "quote": "Winning isn't everything, it's the only thing.",
     "author": "Vince Lombardi"
   },
@@ -5686,10 +5014,6 @@
   {
     "quote": "\u2032Classic\u2032 - a book which people praise and don't read.",
     "author": "Mark Twain"
-  },
-  {
-    "quote": "Take up one idea. Make that one idea your life - think of it, dream of it, live on that idea. Let the brain, muscles, nerves, every part of your body, be full of that idea, and just leave every other idea alone. This is the way to success.",
-    "author": "Swami Vivekananda"
   },
   {
     "quote": "Take up one idea. Make that one idea your life - think of it, dream of it, live on that idea. Let the brain, muscles, nerves, every part of your body, be full of that idea, and just leave every other idea alone. This is the way to success.",
@@ -5725,10 +5049,6 @@
   },
   {
     "quote": "A man is but a product of his thoughts. What he thinks he becomes.",
-    "author": "Mahatma Gandhi"
-  },
-  {
-    "quote": "Happiness is when what you think, what you say, and what you do are in harmony.",
     "author": "Mahatma Gandhi"
   },
   {
@@ -5836,7 +5156,7 @@
     "author": "Thomas Jefferson"
   },
   {
-    "quote": "If with a pure mind a person speaks or acts, happiness follows them like a never-departing shadow.”,
+    "quote": "If with a pure mind a person speaks or acts, happiness follows them like a never-departing shadow.",
     "author": "The Buddha"
   },
   {


### PR DESCRIPTION
**It may be the case that these duplicate files were intentionally added, in which case, please reject this PR.** I noticed throughout the quotes data file that there were quotes that had been duplicated right after the initial quote. For the most part the quotes were just duplicated once, but in several instances I found quotes that had been duplicated up to five times in a row. I deleted these extra quotes, leaving one behind. (I did not look through the data and delete quotes that were duplicates coincidentally, just these duplicates that were right next to each other.). Hopefully, this helps out- thanks!